### PR TITLE
update neointerface - urlencode for uri's

### DIFF
--- a/neointerface/neointerface.py
+++ b/neointerface/neointerface.py
@@ -1832,15 +1832,11 @@ class NeoInterface:
             SET x:Resource            
             SET
             x.
-            `{uri_prop}` = apoc.text.regreplace(
+            `{uri_prop}` = apoc.text.urlencode(
                 $prefix + apoc.text.join($add_prefixes + $opt_label + 
 {"[nbr in nbrs | nbr['map'][$neighbours[nbr['index']]['property']]] +" if neighbours else ""} 
 [prop in $properties | x[prop]], $sep)
-            ,
-                '\\s'
-            ,
-                '%20'
-            )  // for the sake of uri spaces are replaced with %20             
+            )             
             """
             cypher_dict = {
                 'prefix': prefix,
@@ -1959,6 +1955,22 @@ class NeoInterface:
             parameters: {cypher_dict2}
             """)
         self.query(cypher2, cypher_dict2)
+
+        # URIs - replace selected encoded values with their original characters
+        cypher3 = """
+        MATCH (n)
+        WHERE n.uri is not null
+        SET n.uri = apoc.text.replace(n.uri, '%23', '#')
+        SET n.uri = apoc.text.replace(n.uri, '%2F', '/')
+        SET n.uri = apoc.text.replace(n.uri, '%3A', ':')
+        """
+        cypher_dict3 = {}
+        if self.debug:
+            print(f"""
+            query: {cypher3}
+            parameters: {cypher_dict3}
+            """)
+        self.query(cypher3, cypher_dict3)
 
     def rdf_get_graph_onto(self):
         """

--- a/neointerface/neointerface.py
+++ b/neointerface/neointerface.py
@@ -1856,6 +1856,7 @@ class NeoInterface:
                 parameters: {cypher_dict}
                 """)
             self.query(cypher, cypher_dict)
+            self._rdf_uri_cleanup()
 
     def rdf_get_subgraph(self, cypher: str, cypher_dict={}, format="Turtle-star") -> str:
         """
@@ -1865,6 +1866,7 @@ class NeoInterface:
         :param format: RDF format in which to serialize output
         :return: str - RDF serialization of subgraph
         """
+        self._rdf_subgraph_cleanup()
         url = self.rdf_host + "neo4j/cypher"
         j = ({'cypher': cypher, 'format': format, 'cypherParams': cypher_dict})
         response = requests.post(
@@ -1910,13 +1912,13 @@ class NeoInterface:
             parameters: {cypher_dict}
             """)
         res = self.query(cypher, cypher_dict)
-        self._rdf_import_subgraph_cleanup()
+        self._rdf_subgraph_cleanup()
         if len(res) > 0:
             return res[0]
         else:
             return {'triplesParsed': 0, 'triplesLoaded': 0, 'extraInfo': ''}
 
-    def _rdf_import_subgraph_cleanup(self):
+    def _rdf_subgraph_cleanup(self):
         # in case labels with spaces where serialized new labels with spaces being replaced with %20 could have been created
         # this helper function is supposed to revert the change
         cypher = """
@@ -1956,7 +1958,10 @@ class NeoInterface:
             """)
         self.query(cypher2, cypher_dict2)
 
-        # URIs - replace selected encoded values with their original characters
+        self._rdf_uri_cleanup()
+
+    def _rdf_uri_cleanup(self):
+        # URIs - replace selected encoded values with their original characters (for readability)
         cypher3 = """
         MATCH (n)
         WHERE n.uri is not null

--- a/tests/test_rdf_support.py
+++ b/tests/test_rdf_support.py
@@ -18,8 +18,10 @@ def test_rdf_generate_uri(db):
         'Car': ['model', 'fuel']
     })
     result = db.query("MATCH (x:Resource) WHERE not x:_GraphConfig RETURN x.uri order by labels(x)")
-    expected_result = [{'x.uri': 'neo4j://graph.schema#Any%20Vehicle/car/toyota'},
+    expected_result = [{'x.uri': 'neo4j://graph.schema#Any+Vehicle/car/toyota'},
                        {'x.uri': 'neo4j://graph.schema#Car/toyota/petrol'}]
+    # print(result)
+    # print(expected_result)
     assert result == expected_result
 
 
@@ -32,7 +34,7 @@ def test_rdf_generate_uri_dct(db):
         'Car': {'properties': ['model', 'fuel']}
     })
     result = db.query("MATCH (x:Resource) WHERE not x:_GraphConfig RETURN x.uri order by labels(x)")
-    expected_result = [{'x.uri': 'neo4j://graph.schema#Any%20Vehicle/car/toyota'},
+    expected_result = [{'x.uri': 'neo4j://graph.schema#Any+Vehicle/car/toyota'},
                        {'x.uri': 'neo4j://graph.schema#Car/toyota/petrol'}]
     assert result == expected_result
 
@@ -50,7 +52,7 @@ def test_rdf_generate_uri_where(db):
         'Car': {'properties': ['model', 'fuel']}
     })
     result = db.query("MATCH (x:Resource) WHERE not x:_GraphConfig RETURN x.uri order by labels(x)")
-    expected_result = [{'x.uri': 'neo4j://graph.schema#Any%20Vehicle/car/suzuki'},
+    expected_result = [{'x.uri': 'neo4j://graph.schema#Any+Vehicle/car/suzuki'},
                        {'x.uri': 'neo4j://graph.schema#Car/toyota/petrol'}]
     assert result == expected_result
 
@@ -152,7 +154,7 @@ def test_get_graph_onto(db):
 
 
 def test_rdf_import_fetch(db):
-    result = db.rdf_import_fetch('https://raw.githubusercontent.com/phuse-org/rdf.cdisc.org/master/std/sdtm-1-3.ttl',
+    result = db.rdf_import_fetch('https://www.w3.org/2006/time',
                                  'Turtle')
     assert len(result) > 0
     assert result[0]['triplesParsed'] > 0
@@ -170,7 +172,7 @@ def test_rdf_star_import_export_spaces(db):
         'Car': ['v model', 'fuel']
     })
     ttl = db.rdf_get_subgraph("MATCH p=(c)-[*0..1]->() RETURN p")
-    print(ttl)
+    # print(ttl)
     db.clean_slate()
     db.rdf_import_subgraph_inline(ttl)
     result = db.query("""


### PR DESCRIPTION
@paltusplintus 
all URI's are now encoded using apoc.text.urlencode.
for readability, three encoded characters are decoded via _rdf_import_subgraph_cleanup.

@WillMcDGSK - FYI