### PR TITLE
removed deprecated method iteritems and replaced with items

### DIFF
--- a/neointerface/neointerface.py
+++ b/neointerface/neointerface.py
@@ -1444,7 +1444,7 @@ class NeoInterface:
 
         numeric_columns = []
         if ignore_nan:
-            for col, dtype in df.dtypes.iteritems():
+            for col, dtype in df.dtypes.items():
                 if dtype in ['float64', 'int64']:
                     numeric_columns.append(col)
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ for line in requirements:
 
 setuptools.setup(
     name="neointerface",                     # This is the name of the package
-    version="3.3.1",                         # The initial release version
+    version="3.3.2",                         # The initial release version
     author="Alexey Kuznetsov, Julian West, Ben Grinsted, William McDermott",  # Full name of the authors
     description="A Python interface to use the Neo4j graph database",
     long_description="https://github.com/GSK-Biostatistics/neointerface/blob/main/README.md",      # Long description read from the the readme file


### PR DESCRIPTION
@Vidhisri56 Please review.
@paltusplintus FYI.

This is a quick bugfix where the deprecated function iteritems() has been replaced with items().
