### PR TITLE
bugfixes

### DIFF
--- a/neointerface/neointerface.py
+++ b/neointerface/neointerface.py
@@ -17,6 +17,7 @@ from warnings import warn
 from networkx import MultiDiGraph
 from neo4j.graph import Node, Relationship, Path
 from logger.logger import logger
+import math
 
 
 class NeoInterface:
@@ -1451,7 +1452,11 @@ class NeoInterface:
         :return:                List of node ids, created in the operation
         """
         if isinstance(df, pd.Series):
-            df = pd.DataFrame(df)
+            if df.name is None:
+                df = pd.DataFrame(df, columns = [label])
+            else:
+                df = pd.DataFrame(df)
+                
         if rename is not None:
             df = df.rename(rename, axis=1)  # Rename the columns in the Pandas data frame
 


### PR DESCRIPTION
@paltusplintus Please review!

This PR is for this [PBI ](https://dev.azure.com/DevOps-RD/Clinical%20Linked%20Data%20Experiments/_sprints/taskboard/Clinical%20Linked%20Data%20Experiments%20Team/Clinical%20Linked%20Data%20Experiments/Sprint%2013.1?workitem=1386613)and includes minor bugfix and test cases as suggested by Julian.

Below are the changes:
1  When the max_chunk_size exactly equals the # of rows in the dataframe, the number of chunks is computed incorrectly (didn't ascertain what happens as a result) 
---   **The code was working fine, there was no issue. Added the test case for this.**
2  If the argument df is a Pandas SERIES with no name (instead of a dataframe), it crashes
---   **A minor fix has resolved the issue. Added the test case for this.**
3  Merging with NaN's fails, even if merge_overwrite is True
---   **The code was working fine, there was no issue. Added the test case for this.**